### PR TITLE
Add a monitoring endpoint

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,7 @@ env LOG_DIRECTIVE;
 env MAIL_SMTP_USER;
 env MAIL_SMTP_PASSWORD;
 env MAIL_SMTP_SERVER;
+env MONITOR;
 
 worker_processes ${{NUM_WORKERS}};
 error_log ${{LOG_DIRECTIVE}};
@@ -73,6 +74,13 @@ http {
         location /static/ {
             alias static/;
         }
+
+        # nginx server status used for monitoring
+        location /nginx_status {
+            stub_status on;
+            allow 127.0.0.1;
+            deny all;
+        }
     }
 
     server {
@@ -121,8 +129,16 @@ http {
             if ${{ENABLE_AUTO_SSL}} then auto_ssl:challenge_server() end
           }
         }
+
+        # nginx server status used for monitoring
+        location /nginx_status {
+            stub_status on;
+            allow 127.0.0.1;
+            deny all;
+        }
     }
 
+    # For auto-ssl regeneration
     server {
         listen 127.0.0.1:8999;
 


### PR DESCRIPTION
This is a built-in nginx feature which reports active server stats,
most useful is the number of current connections.
When on the server you can see the data by doing `curl http://127.0.0.1/nginx_status`.

This is also what allows the amplify agent to pickup some data.