### PR TITLE
Add arena.csc.ncsu.edu to the whitelisted servers

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -67,6 +67,7 @@ domain_allowed['web.media.mit.edu'] = true
 domain_allowed['snap.apps.miosoft.com'] = true
 -- Snap! Research Projects
 domain_allowed['eliza.csc.ncsu.edu'] = true
+domain_allowed['arena.csc.ncsu.edu'] = true
 domain_allowed['lambda.cs10.org'] = true
 -- All edX Sites, and test sites
 domain_allowed['courses.edge.edx.org'] = true


### PR DESCRIPTION
NCSU runs research branches of Snap that add additional help features. Teachers appreciate still having access to the cloud when using our versions. This PR adds our primary server, arena.csc.ncsu.edu, to the whitelist, in addition to our backup server, eliza, which is already listed.