### PR TITLE
add the current domain to the <head> of snap.html

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -73,6 +73,8 @@ http {
         }
 
         location /snap/ {
+            sub_filter <head>
+                    '<head>\n\t<meta name=\'snap-cloud-domain\' location=\'${{HOSTNAME}}:${{PORT}}\'>';
             alias snap/;
         }
 
@@ -121,6 +123,8 @@ http {
         }
 
         location /snap/ {
+            sub_filter <head>
+                    '<head>\n\t<meta name=\'snap-cloud-domain\' location=\'${{HOSTNAME}}:${{PORT}}\'>';
             alias snap/;
         }
 


### PR DESCRIPTION
This will allow us to always serve snap with the cloud domain -- among other things, this will make it easy to test, and when the staging server is up, it will have it default to the correct url.

Works with https://github.com/jmoenig/Snap--Build-Your-Own-Blocks/pull/2123