### PR TITLE
Added stemc server to domain_allowed.

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -70,6 +70,7 @@ domain_allowed['snap.apps.miosoft.com'] = true
 -- Snap! Research Projects
 domain_allowed['eliza.csc.ncsu.edu'] = true
 domain_allowed['arena.csc.ncsu.edu'] = true
+domain_allowed['stemc.csc.ncsu.edu'] = true
 domain_allowed['lambda.cs10.org'] = true
 -- All edX Sites, and test sites
 domain_allowed['courses.edge.edx.org'] = true


### PR DESCRIPTION
NCSU started a project, STEM+C, to integrate computational thinking into middle school STEM classes. Researchers run branches of Snap! to collect students interactions with the Snap! environment to improve curriculum design. Teachers appreciate still having access to the cloud when using our versions. This PR adds the primary server dedicated to the STEM+C project, stemc.csc.ncsu.edu, to the whitelist, in addition to our servers, arena and eliza, which is already listed.