### PR TITLE
Update start.sh to work w/ staging environment

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-source ../setenv
-authbind --deep lapis server production
+source .env
+authbind --deep lapis server $LAPIS_ENVIRONMENT


### PR DESCRIPTION
* You should now use a `./.env` for the environment
* On a real server it should define `LAPIS_ENVIRONMENT`.

The reason for choosing `.env` is that there are a number of tools which use `.env` as the default file for local configurations. 
One of this is [Overmind](https://github.com/DarthSim/overmind) which basically just makes managing processes easier, since it can handle an app server + db and so on.