### PR TITLE
Tweak cs10-staging to work with lets encrypt

### DIFF
--- a/nginx.conf.d/cs10.org-staging.conf
+++ b/nginx.conf.d/cs10.org-staging.conf
@@ -6,12 +6,14 @@ auth_basic_user_file .htpasswd;
 
 include nginx.conf.d/ssl.conf;
 # LetsEncrypt creates *.pem files by default.
-ssl_certificate     certs/snap-staging_cs10_org-fullchain.pem;
-ssl_certificate_key certs/snap-staging_cs10_org-privkey.pem;
-
-# Needed for LetsEncrypt certbot to authenticate
+ssl_certificate     certs/snap-staging.cs10.org/fullchain.pem;
+ssl_certificate_key certs/snap-staging.cs10.org/privkey.pem;
+  
+# Needed for LetsEncrypt certbot to authenticate the domain
+# HTTP Basic Auth must be disabled so certbot can access the endpoint.
 # Note: This is mapped to ./html/.well-known/acme-challenge
 location ~ /.well-known/acme-challenge/ {
+    auth_basic off;
     allow all;
     default_type "text/plain";
 }

--- a/nginx.conf.d/locations.conf
+++ b/nginx.conf.d/locations.conf
@@ -21,6 +21,7 @@ location /static/ {
 
 # nginx amplify server monitoring
 location /nginx_status {
+    auth_basic: off; # override any auth settings on a staging server.
     stub_status on;
     allow 127.0.0.1;
     deny all;


### PR DESCRIPTION
I made the file names match what's on the server, and what comes back from the letsencrypt bot. 

Basic auth needs to be disabled, otherwise the certbot can't access the files. (The snap-cloud.cs10 file is fine, since it doesn't have basic auth at all.)