### PR TITLE
Add sub-filter to social site HTML

### DIFF
--- a/nginx.conf.d/locations.conf
+++ b/nginx.conf.d/locations.conf
@@ -12,6 +12,7 @@ location /snap/ {
 }
 
 location /site/ {
+    sub_filter <head> '<head>\n\t<meta name="snap-cloud-domain" location="$scheme://$host:$server_port">';
     alias site/www/;
 }
 


### PR DESCRIPTION
This will make the social site default to using the same cloud domain in development or on the staging server like Snap! does.