### PR TITLE
Allow Admins to View Unshared Projects

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -541,7 +541,9 @@ app:match('project_meta', '/projects/:username/:projectname/metadata', respond_t
         local project = Projects:find(self.params.username, self.params.projectname)
 
         if not project then yield_error(err.nonexistent_project) end
-        if not project.ispublic then assert_users_match(self, err.not_public_project) end
+        if not project.ispublic and not user_is_admin(self) then
+             assert_users_match(self, err.not_public_project)
+         end
 
         return jsonResponse(project)
     end),

--- a/app.lua
+++ b/app.lua
@@ -67,9 +67,14 @@ require 'responses'
 
 -- Make cookies persistent
 app.cookie_attributes = function(self)
+    local secure = ' Secure;'
+    -- Exclude security restriction in development
+    if package.loaded.config._name == 'development' then
+        secure = ''
+    end
     local date = require("date")
     local expires = date(true):adddays(365):fmt("${http}")
-    return "Expires=" .. expires .. "; Path=/; HttpOnly; Secure"
+    return "Expires=" .. expires .. "; Path=/; HttpOnly;" .. secure
 end
 
 -- Database abstractions

--- a/validation.lua
+++ b/validation.lua
@@ -70,6 +70,11 @@ users_match = function (self)
     return (self.session.username == self.params.username)
 end
 
+user_is_admin = function (self)
+    local user = Users:find(self.session.username)
+    return user.isadmin
+end
+
 assert_user_exists = function (self, message)
     if not Users:find(self.params.username) then
         yield_error(message or err.nonexistent_user)


### PR DESCRIPTION
They already have the ability to download the files. ;)

This adds a `user_is_admin(self)` method.

_Note_: Pull after #103