### PR TITLE
Fix Checking User Verification Status

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -63,7 +63,7 @@ app:match('current_user', '/users/c', respond_to({
     OPTIONS = cors_options,
     GET = function (self)
 
-        if (self.session.username ~= nil and self.session.username ~= '' and self.session.verified == nil) then
+        if (self.session.username ~= nil and self.session.username ~= '' and not self.session.verified) then
             self.session.verified = (Users:find(self.session.username)).verified
         elseif self.session.username == '' then
             self.session.isadmin = false


### PR DESCRIPTION
Use `not verified` to refresh user status.
This is because `verified` was set to false when they signed in the first time.