### PR TITLE
Update SSL paths for snap-cloud.cs10

### DIFF
--- a/nginx.conf.d/ssl-production.conf
+++ b/nginx.conf.d/ssl-production.conf
@@ -17,8 +17,8 @@ server {
     server_name snap-cloud.cs10.org;
 
     # LetsEncrypt creates *.pem files by default.
-    ssl_certificate     certs/snap-cloud_cs10_org-fullchain.pem;
-    ssl_certificate_key certs/snap-cloud_cs10_org-privkey.pem;
+    ssl_certificate     certs/snap-cloud.cs10.org/fullchain.pem;
+    ssl_certificate_key certs/snap-cloud.cs10.org/privkey.pem;
 
     # Needed for LetsEncrypt certbot to authenticate
     # Note: This is mapped to ./html/.well-known/acme-challenge


### PR DESCRIPTION
These are closer to the lets encrypt default paths. 
This makes the auto-update process a bit easier to manage.

Partial fix #80 