### PR TITLE
Remove https restriction from cookies

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -69,7 +69,7 @@ require 'responses'
 app.cookie_attributes = function(self)
     local date = require("date")
     local expires = date(true):adddays(365):fmt("${http}")
-    return "Expires=" .. expires .. "; Path=/; HttpOnly; Secure"
+    return "Expires=" .. expires .. "; Path=/; HttpOnly;"
 end
 
 -- Database abstractions


### PR DESCRIPTION
As much as I don't think this is a great idea, we need to remove this if we want people to use Snap<em>!</em> for robotics and be connected to their accounts. The cookie is still `httpOnly` so that's the more important part. 

Replaces #103