### PR TITLE
Don't require basic auth for staging API requests

### DIFF
--- a/nginx.conf.d/locations.conf
+++ b/nginx.conf.d/locations.conf
@@ -1,5 +1,6 @@
 # Shared location configurations
 location / {
+    auth_basic off; # (for staging): disable basic auth so that API requests can pass without extra headers.
     default_type text/html;
     content_by_lua_block {
         require("lapis").serve("app")


### PR DESCRIPTION
We want the staging front end behind a password so people don't accidentally save projects to the wrong place.

But, once you've put that password in, the API calls should still work fine, otherwise nginx will expect you to pass in authorization headers. If you're on a staging domain and making API requests to that domain, browsers should automatically send the authorization header, but this change is helpful when  testing from the command line or if you change the URL in Snap<em>!</em>. Both those options are sufficiently complex that it's (hopefully) safe to assume people won't do that by accident.