### PR TITLE
Redirect unknown domains to the default_server

### DIFF
--- a/nginx.conf.d/http-only.conf
+++ b/nginx.conf.d/http-only.conf
@@ -16,5 +16,5 @@ location /snap/ {
 
 # Everything else should be redirected to HTTPS.
 location / {
- return 301 https://$host$request_uri;
+ return 301 https://$server_name$request_uri;
 }


### PR DESCRIPTION
$server_name represents the `default_server` when an unknown domain (like an IP address) is used to visit the Snap!Cloud.

This ensures the redirect goes to the right place. 

Fixes #100