### PR TITLE
Encode username and token URL parameters

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -194,6 +194,8 @@ app:match('resendverification', '/users/:username/resendverification', respond_t
 app:match('password_reset', '/users/:username/password_reset(/:token)', respond_to({
     -- Methods:     GET, POST
     -- Description: Handles password reset requests.
+    --              The route name should match the database token purpose.
+    -- @see validation.create_token
 
     OPTIONS = cors_options,
     GET = capture_errors(function (self)
@@ -280,6 +282,8 @@ app:match('verify_user', '/users/:username/verify_user/:token', respond_to({
     -- Description: Verifies a user's email by means of a token, or removes
     --              that token if it has expired
     --              Returns a success message if the user is already verified.
+    --              The route name should match the database token purpose.
+    -- @see validation.create_token
 
     GET = capture_errors(function (self)
         local user_page = function (user)

--- a/api.lua
+++ b/api.lua
@@ -191,7 +191,7 @@ app:match('resendverification', '/users/:username/resendverification', respond_t
     end)
 }))
 
-app:match('resetpassword', '/users/:username/password_reset(/:token)', respond_to({
+app:match('password_reset', '/users/:username/password_reset(/:token)', respond_to({
     -- Methods:     GET, POST
     -- Description: Handles password reset requests.
 
@@ -275,7 +275,7 @@ app:match('login', '/users/:username/login', respond_to({
 }))
 
 
-app:match('verifyuser', '/users/:username/verify_user/:token', respond_to({
+app:match('verify_user', '/users/:username/verify_user/:token', respond_to({
     -- Methods:     GET
     -- Description: Verifies a user's email by means of a token, or removes
     --              that token if it has expired

--- a/snap-cloud-beta-0.rockspec
+++ b/snap-cloud-beta-0.rockspec
@@ -19,7 +19,8 @@ dependencies = {
    "luasec",
    "luacrypto",
    "xml",
-   "lua-resty-mail"
+   "lua-resty-mail",
+   "luasocket"
 }
 build = {
     type = "builtin",

--- a/validation.lua
+++ b/validation.lua
@@ -127,8 +127,8 @@ create_token = function (self, purpose, username, email)
         self:build_url(self:url_for(
             purpose,
             {
-                username = url.escape(username),
-                token = url.escape(token_value),
+                username = url.build_path({username}),
+                token = url.build_path({token_value}),
             }
         ))
     )

--- a/validation.lua
+++ b/validation.lua
@@ -25,6 +25,7 @@ local db = package.loaded.db
 local Users = package.loaded.Users
 local Projects = package.loaded.Projects
 local Tokens = package.loaded.Tokens
+local url = require 'socket.url'
 
 require 'responses'
 require 'email'
@@ -106,6 +107,11 @@ check_token = function (token_value, purpose, on_success)
     end
 end
 
+--- Creates a token and sends an email
+-- @param self: request object
+-- @param purpose string: token purpose and route name
+-- @param username string
+-- @param email string
 create_token = function (self, purpose, username, email)
     local token_value = secure_token()
     Tokens:create({
@@ -118,5 +124,12 @@ create_token = function (self, purpose, username, email)
         email,
         mail_subjects[purpose] .. username,
         mail_bodies[purpose],
-        self:build_url('/users/' .. username .. '/' .. purpose .. '/' .. token_value))
+        self:build_url(self:url_for(
+            purpose,
+            {
+                username = url.escape(username),
+                token = url.escape(token_value),
+            }
+        ))
+    )
 end


### PR DESCRIPTION
Fixes #114 

This leverages [LuaSocket's `url.escape()`](http://w3.impa.br/~diego/software/luasocket/url.html#escape) and simplifies URL generation via [Lapis's `url_for()`](http://leafo.net/lapis/reference/actions.html#request-object-methods/url_for).