### PR TITLE
Store Session-Only Cookies When Not Persisting Logins

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -48,10 +48,10 @@ require 'passwords'
 app:match('init', '/init', respond_to({
     OPTIONS = cors_options,
     POST = function (self)
-        if not self.session.username or
-            (self.session.username and self.cookies.persist_session == 'false') then
+        if not self.session.username then
             self.session.username = ''
         end
+        return okResponse('')
     end
 }))
 

--- a/app.lua
+++ b/app.lua
@@ -71,8 +71,8 @@ app.cookie_attributes = function(self)
         return "Path=/; HttpOnly;"
     end
     local date = require("date")
-    local expires = "Expires=" .. date(true):adddays(365):fmt("${http}")
-    return  expires .. "; Path=/; HttpOnly;"
+    local expires = date(true):adddays(365):fmt("${http}")
+    return  "Expires=" .. expires .. "; Path=/; HttpOnly;"
 end
 
 -- Database abstractions

--- a/app.lua
+++ b/app.lua
@@ -67,9 +67,12 @@ require 'responses'
 
 -- Make cookies persistent
 app.cookie_attributes = function(self)
+    if (self.cookies.persist_session == 'false') then
+        return "Path=/; HttpOnly;"
+    end
     local date = require("date")
-    local expires = date(true):adddays(365):fmt("${http}")
-    return "Expires=" .. expires .. "; Path=/; HttpOnly;"
+    local expires = "Expires=" .. date(true):adddays(365):fmt("${http}")
+    return  expires .. "; Path=/; HttpOnly;"
 end
 
 -- Database abstractions


### PR DESCRIPTION
I'm not totally sure why the current version works sometimes, but not others.
As such, it's hard to test to see if this really fixes this.
The current system seems to store a cookie,
but "manually" resets the session data when the flag is false.

Session-only cookies simply have no expiration. Instead of unsetting the
 username, this omits the Expiration value causing cookies to be expired when
 you close the window.
 Logging out works as currently done, because the persist flag is false, and the existing cookie is updated.