### PR TITLE
Log more information to nginx logs

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -60,7 +60,7 @@ config({'production', 'staging'}, {
     secret = os.getenv('SESSION_SECRET_BASE'),
     code_cache = 'on',
 
-    log_directive = 'logs/error.log warn',
+    log_directive = 'logs/error.log debug',
 
     -- TODO: See if we can turn this on without a big hit
     measure_performance = false

--- a/nginx.conf
+++ b/nginx.conf
@@ -27,6 +27,16 @@ events {
 }
 
 http {
+    log_format  main_ext  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for" '
+                          '"$host" sn="$server_name" '
+                          'rt=$request_time '
+                          'ua="$upstream_addr" us="$upstream_status" '
+                          'ut="$upstream_response_time" ul="$upstream_response_length" '
+                          'cs=$upstream_cache_status' ;
+    access_log  logs/access.log  main_ext;
+
     include nginx.conf.d/mime.types;
     lua_shared_dict page_cache 15m;
     resolver ${{DNS_RESOLVER}};


### PR DESCRIPTION
This is due to the weird SSL errors by some school districts.
Right now we don't really have enough info to diagnose the problem.