### PR TITLE
Reset Error logging back to 'warn'

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -60,7 +60,7 @@ config({'production', 'staging'}, {
     secret = os.getenv('SESSION_SECRET_BASE'),
     code_cache = 'on',
 
-    log_directive = 'logs/error.log debug',
+    log_directive = 'logs/error.log warn',
 
     -- TODO: See if we can turn this on without a big hit
     measure_performance = false


### PR DESCRIPTION
After we gather enough SSL info, hopefully.

We shouldn't leave this on because it will just waste space.