### PR TITLE
Tweak assert_all to pass in actual functions.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -485,7 +485,7 @@ app:match('project', '/projects/:username/:projectname', respond_to({
             { 'username', exists = true }
         })
 
-        assert_all({'user_exists', 'users_match'}, self)
+        assert_all({assert_user_exists, assert_users_match}, self)
 
         -- Read request body and parse it into JSON
         ngx.req.read_body()

--- a/validation.lua
+++ b/validation.lua
@@ -43,7 +43,11 @@ err = {
 
 assert_all = function (assertions, self)
     for k, assertion in pairs(assertions) do
-        _G['assert_' .. assertion](self)
+        if (type(assertion) == 'string') then
+            _G['assert_' .. assertion](self)
+        else
+            assertion(self)
+        end
     end
 end
 


### PR DESCRIPTION
This makes testing this method work because busted can't see the assert methods on the global scope.

(Also, I personally find this a little nicer to read, but that's just me...)