### PR TITLE
Verify users on save

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -516,6 +516,13 @@ app:match('project', '/projects/:username/:projectname', respond_to({
                 ispublished = self.params.ispublished or project.ispublished
             })
         else
+            -- Users are automatically verified the first time
+            -- they save a project
+            local user = Users:find(self.params.username)
+            if (not user.verified) then
+                user:update({ verified = true })
+            end
+
             Projects:create({
                 projectname = self.params.projectname,
                 username = self.params.username,


### PR DESCRIPTION
Fix #137 

There's no messaging that's different, but maybe that's OK. The next time they log into Snap<em>!</em> they won't need to worry about the message or any verification.