### PR TITLE
Move LetsEncrypt challenge location

### DIFF
--- a/nginx.conf.d/http-only.conf
+++ b/nginx.conf.d/http-only.conf
@@ -10,7 +10,7 @@ location /nginx_status {
 
 # Needed for LetsEncrypt certbot to authenticate
 # Note: This is mapped to snapCloud/html/.well-known/acme-challenge
-location /.well-known/acme-challenge/ {
+location ~ ^/.well-known/acme-challenge/ {
     auth_basic off; # needed for the staging environment.
     alias html/;
     default_type "text/plain";

--- a/nginx.conf.d/http-only.conf
+++ b/nginx.conf.d/http-only.conf
@@ -8,6 +8,14 @@ location /nginx_status {
     deny all;
 }
 
+# Needed for LetsEncrypt certbot to authenticate
+# Note: This is mapped to snapCloud/html/.well-known/acme-challenge
+location /.well-known/acme-challenge/ {
+    auth_basic off; # needed for the staging environment.
+    alias html/;
+    default_type "text/plain";
+}
+
 # If someone tries to visit /snap or /snapsource on http redirect them.
 # This makes it easy to maintain 1 set of http-only snap locations.
 location /snap/ {

--- a/nginx.conf.d/http-only.conf
+++ b/nginx.conf.d/http-only.conf
@@ -11,7 +11,6 @@ location /nginx_status {
 # Needed for LetsEncrypt certbot to authenticate
 # Note: This is mapped to snapCloud/html/.well-known/acme-challenge
 # This must be accessible over a non-ssl connection
-# it is duplicated in the SSL config to make testing easier.
 location ~ ^/.well-known/acme-challenge/ {
     auth_basic off; # needed for the staging environment.
     alias html/;

--- a/nginx.conf.d/http-only.conf
+++ b/nginx.conf.d/http-only.conf
@@ -10,6 +10,8 @@ location /nginx_status {
 
 # Needed for LetsEncrypt certbot to authenticate
 # Note: This is mapped to snapCloud/html/.well-known/acme-challenge
+# This must be accessible over a non-ssl connection
+# it is duplicated in the SSL config to make testing easier.
 location ~ ^/.well-known/acme-challenge/ {
     auth_basic off; # needed for the staging environment.
     alias html/;

--- a/nginx.conf.d/locations.conf
+++ b/nginx.conf.d/locations.conf
@@ -6,13 +6,6 @@ location / {
     }
 }
 
-# Needed for LetsEncrypt certbot to authenticate
-# Note: This is mapped to snapCloud/html/.well-known/acme-challenge
-location /.well-known/acme-challenge/ {
-    alias html/;
-    default_type "text/plain";
-}
-
 location /snap/ {
     sub_filter <head> '<head>\n\t<meta name="snap-cloud-domain" location="$scheme://$host:$server_port">';
     alias snap/;

--- a/nginx.conf.d/locations.conf
+++ b/nginx.conf.d/locations.conf
@@ -6,6 +6,13 @@ location / {
     }
 }
 
+# Needed for LetsEncrypt certbot to authenticate
+# Note: This is mapped to snapCloud/html/.well-known/acme-challenge
+location /.well-known/acme-challenge/ {
+    alias html/;
+    default_type "text/plain";
+}
+
 location /snap/ {
     sub_filter <head> '<head>\n\t<meta name="snap-cloud-domain" location="$scheme://$host:$server_port">';
     alias snap/;

--- a/nginx.conf.d/ssl-production.conf
+++ b/nginx.conf.d/ssl-production.conf
@@ -20,13 +20,6 @@ server {
     ssl_certificate     certs/snap-cloud.cs10.org/fullchain.pem;
     ssl_certificate_key certs/snap-cloud.cs10.org/privkey.pem;
 
-    # Needed for LetsEncrypt certbot to authenticate
-    # Note: This is mapped to ./html/.well-known/acme-challenge
-    location /.well-known/acme-challenge/ {
-        allow all;
-        default_type "text/plain";
-    }
-
     include nginx.conf.d/locations.conf;
 }
 

--- a/nginx.conf.d/ssl-staging.conf
+++ b/nginx.conf.d/ssl-staging.conf
@@ -24,13 +24,5 @@ server {
     ssl_certificate     certs/snap-staging.cs10.org/fullchain.pem;
     ssl_certificate_key certs/snap-staging.cs10.org/privkey.pem;
 
-    # Needed for LetsEncrypt certbot to authenticate
-    # Note: This is mapped to ./html/.well-known/acme-challenge
-    location /.well-known/acme-challenge/ {
-        auth_basic off; # certbot can't use passwords.
-        allow all;
-        default_type "text/plain";
-    }
-
     include nginx.conf.d/locations.conf;
 }


### PR DESCRIPTION
This needs to be accessible without SSL, because it needs to work before a cert is created.

(The current location breaks the renewal process, but I manually renewed the certs and we are good til Feb.)