### PR TITLE
Fix Nil Check for project remix id.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -37,6 +37,8 @@ local Projects = package.loaded.Projects
 local Tokens = package.loaded.Tokens
 local Remixes = package.loaded.Remixes
 
+local cjson = require('cjson')
+
 require 'disk'
 require 'responses'
 require 'validation'
@@ -549,7 +551,7 @@ app:match('project', '/projects/:username/:projectname', respond_to({
             })
             project = Projects:find(self.params.username, self.params.projectname)
 
-            if body.remixID then
+            if (body.remixID ~= cjson.null) then
                 -- user is remixing a project
                 Remixes:create({
                     original_project_id = body.remixID,


### PR DESCRIPTION
We must directly compare against `cjson.null` when checking is a JSON value is null. Because this is a lua object, it is truthy. 😑 

Null values in JSON are serialized by cjson as `cjson.null` because a lua table in the array from (`{1, 2, 3...}`) cannot contain a nil value.

Discovered on the cloud.snap.berkeley.edu site.
https://forum.snap.berkeley.edu/t/project-could-not-be-saved/194/3