### PR TITLE
Fix #167 Part 2

### DIFF
--- a/disk.lua
+++ b/disk.lua
@@ -86,7 +86,7 @@ function parse_notes(id, delta)
                 notes = xml.find(project, 'notes')[1]
             end) then
             project_file:close()
-            return notes
+            return notes or ''
         else
             project_file:close()
             return ''


### PR DESCRIPTION
The XML library we're using still returns nil when there's no content even (such as `<notes></notes>`)