### PR TITLE
Use ILIKE not ~* for matching text

### DIFF
--- a/controllers/project.lua
+++ b/controllers/project.lua
@@ -49,7 +49,7 @@ ProjectController = {
                 if self.params.matchtext then
                     query = query ..
                         db.interpolate_query(
-                            ' and (projectname ~* ? or notes ~* ?)',
+                            ' and (projectname ILIKE ? or notes ILIKE ?)',
                             self.params.matchtext,
                             self.params.matchtext
                         )
@@ -100,7 +100,7 @@ ProjectController = {
             if self.params.matchtext then
                 query = query ..
                     db.interpolate_query(
-                        ' and (projectname ~* ? or notes ~* ?)',
+                        ' and (projectname ILIKE ? or notes ILIKE ?)',
                         self.params.matchtext,
                         self.params.matchtext
                     )
@@ -377,7 +377,7 @@ ProjectController = {
             local body = body_data and util.from_json(body_data) or nil
             local new_name = body and body.projectname or nil
             local new_notes = body and body.notes or nil
-            
+
             -- save new notes and project name into the project XML
             if new_notes then update_notes(project.id, new_notes) end
             if new_name then update_name(project.id, new_name) end

--- a/controllers/user.lua
+++ b/controllers/user.lua
@@ -69,7 +69,7 @@ UserController = {
                 paginator = Users:paginated(
                     self.params.matchtext and
                         db.interpolate_query(
-                            'where username ~* ? or email ~* ?',
+                            'where username ILIKE ? or email ILIKE ?',
                             self.params.matchtext,
                             self.params.matchtext
                         )
@@ -81,7 +81,7 @@ UserController = {
                 )
             else
                 paginator = Users:paginated(
-                    db.interpolate_query('where username ~* ?', self.params.matchtext),
+                    db.interpolate_query('where username ILIKE ?', self.params.matchtext),
                     {
                         per_page = self.params.pagesize or 16,
                         fields = 'username'
@@ -179,7 +179,7 @@ UserController = {
             -- Parameters:  username, password, password_repeat, email, role
             if (self.current_user) then
                 -- user is updating profile, or an admin is updating somebody else's profile
-                if not users_match(self) then 
+                if not users_match(self) then
                     if self.params.role then
                         assert_can_set_role(self, self.params.role)
                     else


### PR DESCRIPTION
We can't enable regex as a default search.
It's possible to construct regular expressions that would slow down the DB.

Ideally we should set a DB timeout limit on queries too...