### PR TITLE
Give Admins More Super Powers

### DIFF
--- a/validation.lua
+++ b/validation.lua
@@ -121,7 +121,7 @@ assert_can_set_role = function (self, role)
 end
 
 users_match = function (self)
-    return (self.session.username == self.params.username)
+    return (self.session.username == self.params.username) or (self.current_user and self.current_user:isadmin())
 end
 
 assert_users_match = function (self, message)


### PR DESCRIPTION
Allow users_match to return true so admins can inspect/do anything.

I'm not 100% sure this is the best approach, but it is pretty effective. 