### PR TITLE
Tweak permissions

### DIFF
--- a/validation.lua
+++ b/validation.lua
@@ -96,6 +96,8 @@ end
 assert_can_set_role = function (self, role)
     -- Admins can set any user to any role.
     -- Banned and standard users have no ability to edit roles.
+    -- Moderators and Reviews can edit the roles of users "lower" than
+    -- themselves.
     if self.current_user:isadmin() then
         return
     elseif self.current_user:has_one_of_roles({ 'banned', 'standard' }) then


### PR DESCRIPTION
Just an idea...

I think it only makes sense to bump users one level at a time. A moderator could just bump someone 3 times in a row, I guess, but mostly I think it will help to to prevent accidents as a team of people grows. 